### PR TITLE
Fix `SharedAssetLoader.load`

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/SharedAssetLoader.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/SharedAssetLoader.js
@@ -146,7 +146,9 @@ define(["require", "exports", "webfontloader", "./Random", "./Utils", "./pixijs"
             }
             if (this.loader.loading) {
                 this.loader.onComplete.once(function () {
-                    _this._load.apply(_this, __spreadArray([callback], __read(assets), false));
+                    // use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
+                    // while the handler is executing which results in an infinite (indirect) recursion
+                    setTimeout(function () { return _this.load.apply(_this, __spreadArray([callback], __read(assets), false)); }, 0);
                 });
             }
             else {

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/SharedAssetLoader.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/SharedAssetLoader.js
@@ -146,7 +146,8 @@ define(["require", "exports", "webfontloader", "./Random", "./Utils", "./pixijs"
             }
             if (this.loader.loading) {
                 this.loader.onComplete.once(function () {
-                    // use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
+                    // Call `load` again to make sure that the PIXI.Loader is not 'loading'.
+                    // Use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
                     // while the handler is executing which results in an infinite (indirect) recursion
                     setTimeout(function () { return _this.load.apply(_this, __spreadArray([callback], __read(assets), false)); }, 0);
                 });

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/SharedAssetLoader.ts
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/SharedAssetLoader.ts
@@ -124,7 +124,9 @@ export class SharedAssetLoader {
 	static load(callback:() => void, ...assets: (Asset|FontAsset|undefined)[]) {
 		if(this.loader.loading) {
 			this.loader.onComplete.once(() => {
-				this._load(callback, ...assets)
+				// use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
+				// while the handler is executing which results in an infinite (indirect) recursion
+				setTimeout(() => this.load(callback, ...assets), 0)
 			})
 		} else {
 			this._load(callback, ...assets)

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/SharedAssetLoader.ts
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/SharedAssetLoader.ts
@@ -124,7 +124,8 @@ export class SharedAssetLoader {
 	static load(callback:() => void, ...assets: (Asset|FontAsset|undefined)[]) {
 		if(this.loader.loading) {
 			this.loader.onComplete.once(() => {
-				// use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
+				// Call `load` again to make sure that the PIXI.Loader is not 'loading'.
+				// Use timeout since (if the loader is loading) the 'load' call adds a new 'onComplete' handler
 				// while the handler is executing which results in an infinite (indirect) recursion
 				setTimeout(() => this.load(callback, ...assets), 0)
 			})


### PR DESCRIPTION
# Description

The `PIXI.Loader` can only `add` assets, if it is not loading. We have to check that it is not loading.

## Type of change

In `onComplete`:  Call `load` instead of `_load`, such that we check that the `PIXI.Loader` is not loading. We also need to use `setTimeout`, otherwise we have an infinite recursion.

- [x] Bug fix (non-breaking change which fixes an issue)